### PR TITLE
feat: add monetization features with ad integration and legal pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,12 @@
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700;900&display=swap"
       rel="stylesheet"
     />
+
+    <script
+      async
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXX"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body class="bg-gray-900 text-white overflow-x-hidden">
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,8 @@ import Series from './pages/Series.jsx';
 import Favorites from './pages/Favorites.jsx';
 import Details from './pages/Details.jsx';
 import NotFound from './pages/NotFound.jsx';
+import PrivacyPolicy from "./pages/PrivacyPolicy.jsx";
+import LegalNotice from "./pages/LegalNotice.jsx";
 
 export default function App() {
   return (
@@ -17,6 +19,8 @@ export default function App() {
         <Route path="/series" element={<Series />} />
         <Route path="/favorites" element={<Favorites />} />
         <Route path="/details" element={<Details />} />
+        <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+        <Route path="/legal-notice" element={<LegalNotice />} />
 
         {/* compat anciens liens */}
         <Route path="/index.html" element={<Navigate to="/" replace />} />

--- a/src/components/AdBanner.jsx
+++ b/src/components/AdBanner.jsx
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+
+export default function AdBanner({
+  className = "",
+  style = { display: "block" },
+  format = "auto",
+  responsive = "true",
+}) {
+  useEffect(() => {
+    try {
+      window.adsbygoogle = window.adsbygoogle || [];
+      window.adsbygoogle.push({});
+    } catch {
+    }
+  }, []);
+
+  return (
+    <div className={`my-10 flex justify-center ${className}`}>
+      <ins
+        className="adsbygoogle"
+        style={style}
+        data-ad-client="ca-pub-XXXXXXXXXXXX"
+        data-ad-slot="YYYYYYYYYY"
+        data-ad-format={format}
+        data-full-width-responsive={responsive}
+      />
+    </div>
+  );
+}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,10 +1,17 @@
+import { Link } from 'react-router-dom';
+
 export default function Footer() {
   return (
-    <footer className="flex justify-center items-center bg-black text-white h-20 mt-10">
+    <footer className="flex flex-col justify-center items-center bg-black text-white h-20 mt-10">
       <h1>
         Copyright©2025 -{' '}
         <span className="text-yellow-500 font-bold font-cinzel">Z</span>inema.
       </h1>
+
+      <div className="flex space-x-4 text-sm text-gray-400 mt-2">
+        <Link to="/legal-notice">Mentions légales</Link>
+        <Link to="/privacy-policy">Politique de confidentialité</Link>
+      </div>
     </footer>
   );
 }

--- a/src/pages/Details.jsx
+++ b/src/pages/Details.jsx
@@ -13,6 +13,7 @@ import {
 import StarButton from '../components/StarButton.jsx';
 import Carousel from '../components/Carousel.jsx';
 import Reviews from '../components/Reviews.jsx';
+import AdBanner from "../components/AdBanner.jsx";
 
 function badge(label) {
   return (
@@ -264,6 +265,8 @@ export default function Details() {
               </div>
             </div>
           ) : null}
+
+          <AdBanner />
 
           {recs.length ? (
             <Carousel

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { getPopularMovies, getPopularSeries, img } from '../services/tmdb.js';
 import Carousel from '../components/Carousel.jsx';
+import AdBanner from "../components/AdBanner.jsx";
 import { Link } from 'react-router-dom';
 
 export default function Home() {
@@ -80,6 +81,7 @@ export default function Home() {
         ) : (
           <>
             <Carousel title="Films populaires" items={movies.slice(0, 12)} type="movie" />
+            <AdBanner />
             <Carousel title="Séries populaires" items={series.slice(0, 12)} type="tv" />
           </>
         )}

--- a/src/pages/LegalNotice.jsx
+++ b/src/pages/LegalNotice.jsx
@@ -1,0 +1,71 @@
+export default function LegalNotice() {
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-16 text-gray-200">
+      <h1 className="text-3xl font-bold mb-8">Mentions légales</h1>
+
+      <h2 className="text-xl font-semibold mt-6 mb-3">1. Éditeur du site</h2>
+      <p className="mb-4">
+        Nom du site : <strong>Zynema</strong>
+        <br />
+        Responsable de publication :{" "}
+        <strong>Dorian ABBDESSA / Antonin TACCHI</strong>
+        <br />
+        Contact : <strong>Zinema@antonin-tacchi.com</strong>
+      </p>
+
+      <h2 className="text-xl font-semibold mt-6 mb-3">2. Hébergement</h2>
+      <p className="mb-4">
+        Le site est hébergé par :
+        <br />
+        <strong>Hostinger International Ltd.</strong>
+        <br />
+        61 Lordou Vironos Street
+        <br />
+        6023 Larnaca
+        <br />
+        Chypre
+        <br />
+        <a
+          href="https://www.hostinger.com"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-400 underline"
+        >
+          https://www.hostinger.com
+        </a>
+      </p>
+
+      <h2 className="text-xl font-semibold mt-6 mb-3">
+        3. Propriété intellectuelle
+      </h2>
+      <p className="mb-4">
+        L’ensemble du contenu présent sur le site Zynema (structure, design,
+        code) est protégé par le droit d’auteur.
+      </p>
+
+      <p className="mb-4">
+        Les affiches, images et informations relatives aux films et séries sont
+        fournies par l’API <strong>TMDB</strong>.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-6 mb-3">4. Responsabilité</h2>
+      <p className="mb-4">
+        Zynema est une application de découverte de contenus cinématographiques.
+        Aucun contenu vidéo n’est hébergé ou diffusé directement par le site.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-6 mb-3">
+        5. Données personnelles
+      </h2>
+      <p className="mb-4">
+        Pour plus d’informations concernant la gestion des données personnelles,
+        veuillez consulter la page
+        <strong> Politique de confidentialité</strong>.
+      </p>
+
+      <p className="mt-10 text-sm text-gray-400">
+        Dernière mise à jour : {new Date().toLocaleDateString("fr-FR")}
+      </p>
+    </div>
+  );
+}

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -1,0 +1,74 @@
+export default function PrivacyPolicy() {
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-16 text-gray-200">
+      <h1 className="text-3xl font-bold mb-8">Politique de confidentialité</h1>
+
+      <p className="mb-6">
+        La présente politique de confidentialité décrit la manière dont le site
+        <strong> Zynema</strong> collecte, utilise et protège les informations des utilisateurs.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-3">1. Données personnelles</h2>
+      <p className="mb-4">
+        Zynema ne collecte aucune donnée personnelle permettant d’identifier directement un utilisateur
+        (nom, prénom, adresse email, etc.).
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-3">2. Stockage local</h2>
+      <p className="mb-4">
+        L’application utilise le <strong>LocalStorage</strong> du navigateur afin de sauvegarder :
+      </p>
+      <ul className="list-disc list-inside mb-4">
+        <li>les films et séries ajoutés aux favoris</li>
+        <li>les commentaires ajoutés par l’utilisateur</li>
+      </ul>
+      <p className="mb-4">
+        Ces données restent exclusivement sur l’appareil de l’utilisateur et ne sont jamais transmises
+        à un serveur.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-3">3. Publicité</h2>
+      <p className="mb-4">
+        Zynema utilise des services publicitaires tiers, notamment <strong>Google AdSense</strong>.
+        Ces services peuvent utiliser des cookies ou des technologies similaires afin de proposer
+        des annonces adaptées aux centres d’intérêt des utilisateurs.
+      </p>
+
+      <p className="mb-4">
+        Google peut utiliser le cookie <strong>DoubleClick</strong> pour diffuser des annonces.
+        Les utilisateurs peuvent désactiver la publicité personnalisée en consultant :
+        <br />
+        <a
+          href="https://adssettings.google.com"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-400 underline"
+        >
+          https://adssettings.google.com
+        </a>
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-3">4. Cookies</h2>
+      <p className="mb-4">
+        Zynema n’utilise pas de cookies propriétaires. Des cookies tiers peuvent toutefois être déposés
+        par les services de publicité ou par des plateformes externes.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-3">5. API tierce</h2>
+      <p className="mb-4">
+        Les informations sur les films et séries sont fournies par l’API publique
+        <strong> The Movie Database (TMDB)</strong>.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-3">6. Modification de la politique</h2>
+      <p className="mb-4">
+        Cette politique de confidentialité peut être modifiée à tout moment afin de rester conforme
+        aux évolutions légales ou techniques.
+      </p>
+
+      <p className="mt-10 text-sm text-gray-400">
+        Dernière mise à jour : {new Date().toLocaleDateString("fr-FR")}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces advertising support and legal compliance pages to the application. It adds Google AdSense integration, displays ad banners in key pages, and provides dedicated routes and components for the privacy policy and legal notice. The footer is also updated to link to these new legal pages.

Advertising integration:

* Added the Google AdSense script to `index.html` for site-wide ad support.
* Created a reusable `AdBanner` component to display ads, and integrated it into the `Home` and `Details` pages. [[1]](diffhunk://#diff-7cc7faeab631fad24b2dcf51d5456bd53247ac2846ecbcdf058aa3ecc1462debR1-R29) [[2]](diffhunk://#diff-3f516fbdeb9a7ec0382eddb852845968f9cdaa1cff026ac0ce8fdf1fd351cc17R4) [[3]](diffhunk://#diff-3f516fbdeb9a7ec0382eddb852845968f9cdaa1cff026ac0ce8fdf1fd351cc17R84) [[4]](diffhunk://#diff-dd988c7081c024cf67c6231a2fd13c326d586a1199829dd2aff4b965d00e8e9dR16) [[5]](diffhunk://#diff-dd988c7081c024cf67c6231a2fd13c326d586a1199829dd2aff4b965d00e8e9dR269-R270)

Legal compliance pages:

* Added new `PrivacyPolicy` and `LegalNotice` pages with relevant legal information, and registered their routes in the app. [[1]](diffhunk://#diff-f800dcc04268faa3c17150a5d75cbd3cd0af7e2e24de54687bca7229f70b928dR1-R74) [[2]](diffhunk://#diff-5a2b87aba938ca8518fc09218db67e89abc6cf63125f8c33125f3e31011fc0bfR1-R71) [[3]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R10-R11) [[4]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R22-R23)

UI updates:

* Updated the `Footer` component to include links to the new legal pages for easy user access.